### PR TITLE
feat: Support C++-style single line comments

### DIFF
--- a/inflow.cpp
+++ b/inflow.cpp
@@ -15,7 +15,7 @@ typedef std::pair<ll, ll> pi;
 const ll INF = std::numeric_limits<ll>::max();
 // characters allowed to be in a prefix
 const std::unordered_set<char> PREFIX = {
-    ' ', '>', ':', '-', '*', '|', '#', '$', '%', '"', '\'',
+    ' ', '>', ':', '-', '*', '|', '#', '$', '%', '"', '\'', '/'
 };
 
 // fraction methods

--- a/src/inflow/inflow.py
+++ b/src/inflow/inflow.py
@@ -5,7 +5,7 @@ Block = tuple[list[str], int, str]
 State = tuple[int, float, int, int]
 
 # characters allowed to be in a prefix
-PREFIX = set(" >:-*|#$%'\"")
+PREFIX = set(" >:-*|#$%'\"/")
 
 
 def get_lines(par: list[str], width: int) -> list[int]:


### PR DESCRIPTION
Comments with the `//` prefix (Eg: C++, Java, C99, etc.) were not properly processed. By adding '/', inflow will now treat them as a prefix.
